### PR TITLE
refresh token before it expires

### DIFF
--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -181,19 +181,18 @@ class API:  # pylint: disable=too-many-instance-attributes
         ):
             # Token has to be refreshed, get authentication task if running otherwise
             # start a new one.
-            if self._security_token[0] is None:
-                self._myqrequests.clear_useragent()
-                # Wait for authentication task to be completed.
-                _LOGGER.debug(
-                    "Waiting for updated token, last refresh was %s",
-                    self._security_token[2],
-                )
-                try:
-                    await self.authenticate(wait=True)
-                except AuthenticationError as auth_err:
-                    message = f"Error trying to re-authenticate to myQ service: {str(auth_err)}"
-                    _LOGGER.debug(message)
-                    raise AuthenticationError(message) from auth_err
+            self._myqrequests.clear_useragent()
+            # Wait for authentication task to be completed.
+            _LOGGER.debug(
+                "Waiting for updated token, last refresh was %s",
+                self._security_token[2],
+            )
+            try:
+                await self.authenticate(wait=True)
+            except AuthenticationError as auth_err:
+                message = f"Error trying to re-authenticate to myQ service: {str(auth_err)}"
+                _LOGGER.debug(message)
+                raise AuthenticationError(message) from auth_err
 
     def change_domain(self) -> None:
         """Change to a different domain"""
@@ -535,7 +534,7 @@ class API:  # pylint: disable=too-many-instance-attributes
         _LOGGER.debug("Received token that will expire in %s seconds", expires)
         self._security_token = (
             token,
-            datetime.utcnow() + timedelta(seconds=int(expires / 2)),
+            datetime.utcnow() + timedelta(seconds=int(expires)),
             datetime.now(),
         )
 


### PR DESCRIPTION
The if statement is blocking the refreshing until there isn't a valid token any more. It appears that the token expires after 30 minutes, but the API still responds for 5 more minutes (thus the 35 minutes people are noting). I suspect many of the 429's are actually coming for the frequent authentications to get a new key, so I also removed the division of the expiration time by 2 since there seems to be a 5 minute buffer period on the MyQ side anyway. Hope this is helpful, mine has been running for hours now without any issues. Thanks for your work on this.