### PR TITLE
fix: update oauth get token call for correctness

### DIFF
--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -1,7 +1,7 @@
 """Define the MyQ API."""
 import asyncio
-import logging
 import base64
+import logging
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple, Union
 from urllib.parse import parse_qs, urlsplit
@@ -21,7 +21,6 @@ from .const import (
     OAUTH_AUTHORIZE_URI,
     OAUTH_BASE_URI,
     OAUTH_CLIENT_ID,
-    OAUTH_CLIENT_SECRET,
     OAUTH_REDIRECT_URI,
     OAUTH_TOKEN_URI,
 )

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -1,6 +1,7 @@
 """Define the MyQ API."""
 import asyncio
 import logging
+import base64
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple, Union
 from urllib.parse import parse_qs, urlsplit
@@ -440,24 +441,22 @@ class API:  # pylint: disable=too-many-instance-attributes
             _LOGGER.debug("Getting token")
             redirect_url = f"{OAUTH_BASE_URI}{resp.headers['Location']}"
 
+            gettokenbasicauth = base64.b64encode(f"{OAUTH_CLIENT_ID}:".encode("ascii")).decode("ascii")
             resp, data = await self.request(
                 returns="json",
                 method="post",
                 url=OAUTH_TOKEN_URI,
                 websession=session,
                 headers={
+                    "Authorization": f"Basic {gettokenbasicauth}",
                     "Content-Type": "application/x-www-form-urlencoded",
+                    "Accept": "*/*",
                 },
                 data={
-                    "client_id": OAUTH_CLIENT_ID,
-                    "client_secret": OAUTH_CLIENT_SECRET,
-                    "code": parse_qs(urlsplit(redirect_url).query).get("code", ""),
+                    "code": parse_qs(urlsplit(redirect_url).query).get("code", "")[0],
                     "code_verifier": self._code_verifier,
                     "grant_type": "authorization_code",
                     "redirect_uri": OAUTH_REDIRECT_URI,
-                    "scope": parse_qs(urlsplit(redirect_url).query).get(
-                        "code", "MyQ_Residential offline_access"
-                    ),
                 },
                 login_request=True,
             )

--- a/pymyq/api.py
+++ b/pymyq/api.py
@@ -441,14 +441,14 @@ class API:  # pylint: disable=too-many-instance-attributes
             _LOGGER.debug("Getting token")
             redirect_url = f"{OAUTH_BASE_URI}{resp.headers['Location']}"
 
-            gettokenbasicauth = base64.b64encode(f"{OAUTH_CLIENT_ID}:".encode("ascii")).decode("ascii")
+            get_token_basic_auth = base64.b64encode(f"{OAUTH_CLIENT_ID}:".encode("ascii")).decode("ascii")
             resp, data = await self.request(
                 returns="json",
                 method="post",
                 url=OAUTH_TOKEN_URI,
                 websession=session,
                 headers={
-                    "Authorization": f"Basic {gettokenbasicauth}",
+                    "Authorization": f"Basic {get_token_basic_auth}",
                     "Content-Type": "application/x-www-form-urlencoded",
                     "Accept": "*/*",
                 },


### PR DESCRIPTION
See: https://github.com/home-assistant/core/issues/101763

This PR updates the call to the OAuth get token endpoint to be more in line with the OAuth specs, to fix an issue where MyQ is returning 401 errors.

Please review pretty closely, I don't do a lot of coding in Python. ;)