### PR TITLE
Relax poetry-core upper version bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ beautifulsoup4 = "^4.9.3"
 pkce = "^1.0.2"
 
 [build-system]
-requires = ["poetry-core==1.6.1"]
+requires = ["poetry-core>=1.6.1"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
There is no harm in letting the package build with newer poetry-core builder versions.